### PR TITLE
Dependabot: switch to a weekly cadence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "pnpm" # See documentation for possible values
     directory: "/web" # Location of package manifests
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+    open-pull-requests-limit: 5
     labels:
       - "ok-to-test"
-


### PR DESCRIPTION
Ensure we have weekly updates and limit Dependabot to 5 PRs.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>
