### PR TITLE
fix(index): prevent shifting on dashboard group hover

### DIFF
--- a/web/src/testgrid-index.ts
+++ b/web/src/testgrid-index.ts
@@ -207,18 +207,19 @@ export class TestgridIndex extends LitElement {
     .dashboard {
       background-color: #9e60eb;
       color: #fff;
+      border: 2px solid transparent;
     }
 
     .dashboard-group {
       background-color: #707df1;
       color: #fff;
+      border: 2px solid transparent;
     }
 
     .dashboard-group:focus,
     .dashboard-group:hover {
       background-color: #fff;
       color: #707df1;
-      border-style: solid;
       border-color: #707df1;
     }
 
@@ -226,7 +227,6 @@ export class TestgridIndex extends LitElement {
     .dashboard:focus {
       background-color: #fff;
       color: #9e60eb;
-      border-style: solid;
       border-color: #9e60eb;
     }
 


### PR DESCRIPTION
Add a transparent border to the default state of dashboard and dashboard
group elements to fix shifting on hover

Before:

![before](https://github.com/user-attachments/assets/3336b53b-57c2-4f9e-8534-f032ff6c5b18)

After:

![after](https://github.com/user-attachments/assets/2eb86d52-ca39-460e-9367-54e5f9e7a0c6)
