### PR TITLE
feat(api): utilize Lit ReactiveControllers

### DIFF
--- a/web/src/APIClient.ts
+++ b/web/src/APIClient.ts
@@ -1,39 +1,160 @@
 import {
   ListDashboardsResponse,
   ListDashboardGroupsResponse,
+  ListDashboardTabsResponse,
+  ListTabSummariesResponse,
+  ListHeadersResponse,
+  ListRowsResponse,
+  GetDashboardResponse,
+  ListDashboardSummariesResponse,
 } from './gen/pb/api/v1/data.js';
 
-export interface APIClient {
-  getDashboards(): Array<String>;
-  getDashboardGroups(): Array<String>;
+interface IAPIClient {
+  getDashboards(): Promise<ListDashboardsResponse>;
+  getDashboardGroups(): Promise<ListDashboardGroupsResponse>;
+  getDashboardTabs(dashboardName: string): Promise<ListDashboardTabsResponse>;
+  getTabSummaries(dashboardName: string): Promise<ListTabSummariesResponse>;
+  getTabHeaders(
+    dashboardName: string,
+    tabName: string
+  ): Promise<ListHeadersResponse>;
+  getTabRows(dashboardName: string, tabName: string): Promise<ListRowsResponse>;
+  getDashboard(dashboardName: string): Promise<GetDashboardResponse>;
+  getDashboardSummaries(groupName: string): Promise<ListDashboardSummariesResponse>;
 }
 
-export class APIClientImpl implements APIClient {
-  host: String = 'testgrid-data.k8s.io';
+class APIClient implements IAPIClient {
+  private baseUrl: string;
 
-  public getDashboards(): Array<String> {
-    const dashboards: Array<String> = [];
-
-    fetch(`${this.host}/api/v1/dashboards`).then(async response => {
-      const resp = ListDashboardsResponse.fromJson(await response.json(), {ignoreUnknownFields: true});
-      resp.dashboards.forEach(db => {
-        dashboards.push(db.name);
-      });
-    });
-
-    return dashboards;
+  // TODO(jbpratt): https
+  constructor(
+    baseUrl = `http://${process.env.API_HOST}:${process.env.API_PORT}`
+  ) {
+    this.baseUrl = baseUrl;
   }
 
-  public getDashboardGroups(): Array<String> {
-    const dashboardGroups: Array<String> = [];
+  async getDashboards(): Promise<ListDashboardsResponse> {
+    const response = await fetch(`${this.baseUrl}/api/v1/dashboards`);
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch dashboards: ${response.status} ${response.statusText}`
+      );
+    }
+    const json = await response.json();
+    return ListDashboardsResponse.fromJson(json, { ignoreUnknownFields: true });
+  }
 
-    fetch(`${this.host}/api/v1/dashboard-groups`).then(async response => {
-      const resp = ListDashboardGroupsResponse.fromJson(await response.json(), {ignoreUnknownFields: true});
-      resp.dashboardGroups.forEach(db => {
-        dashboardGroups.push(db.name);
-      });
+  async getDashboardGroups(): Promise<ListDashboardGroupsResponse> {
+    const response = await fetch(`${this.baseUrl}/api/v1/dashboard-groups`);
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch dashboard groups: ${response.status} ${response.statusText}`
+      );
+    }
+    const json = await response.json();
+    return ListDashboardGroupsResponse.fromJson(json, {
+      ignoreUnknownFields: true
     });
+  }
 
-    return dashboardGroups;
+  async getDashboardTabs(
+    dashboardName: string
+  ): Promise<ListDashboardTabsResponse> {
+    const encodedName = encodeURIComponent(dashboardName);
+    const response = await fetch(
+      `${this.baseUrl}/api/v1/dashboards/${encodedName}/tabs`
+    );
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch dashboard tabs for "${dashboardName}": ${response.status} ${response.statusText}`
+      );
+    }
+    const json = await response.json();
+    return ListDashboardTabsResponse.fromJson(json, {
+      ignoreUnknownFields: true
+    });
+  }
+
+  async getTabSummaries(
+    dashboardName: string
+  ): Promise<ListTabSummariesResponse> {
+    const encodedName = encodeURIComponent(dashboardName);
+    const response = await fetch(
+      `${this.baseUrl}/api/v1/dashboards/${encodedName}/tab-summaries`
+    );
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch tab summaries for "${dashboardName}": ${response.status} ${response.statusText}`
+      );
+    }
+    const json = await response.json();
+    return ListTabSummariesResponse.fromJson(json, {
+      ignoreUnknownFields: true
+    });
+  }
+
+  async getTabHeaders(
+    dashboardName: string,
+    tabName: string
+  ): Promise<ListHeadersResponse> {
+    const encodedDashboard = encodeURIComponent(dashboardName);
+    const encodedTab = encodeURIComponent(tabName);
+    const response = await fetch(
+      `${this.baseUrl}/api/v1/dashboards/${encodedDashboard}/tabs/${encodedTab}/headers`
+    );
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch headers for "${dashboardName}/${tabName}": ${response.status} ${response.statusText}`
+      );
+    }
+    const json = await response.json();
+    return ListHeadersResponse.fromJson(json, { ignoreUnknownFields: true });
+  }
+
+  async getTabRows(
+    dashboardName: string,
+    tabName: string
+  ): Promise<ListRowsResponse> {
+    const encodedDashboard = encodeURIComponent(dashboardName);
+    const encodedTab = encodeURIComponent(tabName);
+    const response = await fetch(
+      `${this.baseUrl}/api/v1/dashboards/${encodedDashboard}/tabs/${encodedTab}/rows`
+    );
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch rows for "${dashboardName}/${tabName}": ${response.status} ${response.statusText}`
+      );
+    }
+    const json = await response.json();
+    return ListRowsResponse.fromJson(json, { ignoreUnknownFields: true });
+  }
+
+  async getDashboard(dashboardName: string): Promise<GetDashboardResponse> {
+    const encodedName = encodeURIComponent(dashboardName);
+    const response = await fetch(
+      `${this.baseUrl}/api/v1/dashboards/${encodedName}`
+    );
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch dashboard "${dashboardName}": ${response.status} ${response.statusText}`
+      );
+    }
+    const json = await response.json();
+    return GetDashboardResponse.fromJson(json, { ignoreUnknownFields: true });
+  }
+
+  async getDashboardSummaries(groupName: string): Promise<ListDashboardSummariesResponse> {
+    const encodedGroup = encodeURIComponent(groupName);
+    const response = await fetch(`${this.baseUrl}/api/v1/dashboard-groups/${encodedGroup}/dashboard-summaries`);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch dashboard summaries for group "${groupName}": ${response.status} ${response.statusText}`);
+    }
+    const json = await response.json();
+    return ListDashboardSummariesResponse.fromJson(json, { ignoreUnknownFields: true });
   }
 }
+
+export const apiClient = new APIClient();
+
+export const createApiClient = (baseUrl: string): IAPIClient =>
+  new APIClient(baseUrl);

--- a/web/src/controllers/api-controller.ts
+++ b/web/src/controllers/api-controller.ts
@@ -1,0 +1,66 @@
+import { ReactiveController, ReactiveControllerHost } from 'lit';
+
+export interface ApiState<T> {
+  data: T | null;
+  loading: boolean;
+  error: Error | null;
+}
+
+export class ApiController<T> implements ReactiveController {
+  private host: ReactiveControllerHost;
+
+  private _state: ApiState<T> = { data: null, loading: false, error: null };
+
+  private cache = new Map<string, { data: T; timestamp: number }>();
+
+  private readonly cacheTTL = 5 * 60 * 1000; // 5 minutes
+
+  constructor(host: ReactiveControllerHost) {
+    (this.host = host).addController(this);
+  }
+
+  get state(): ApiState<T> {
+    return this._state;
+  }
+
+  async fetch(key: string, fetcher: () => Promise<T>): Promise<T> {
+    // check if its cached
+    const cached = this.cache.get(key);
+    if (cached && Date.now() - cached.timestamp < this.cacheTTL) {
+      this._state = { data: cached.data, loading: false, error: null };
+      this.host.requestUpdate();
+      return cached.data;
+    }
+
+    this._state = { ...this._state, loading: true, error: null };
+    this.host.requestUpdate();
+
+    try {
+      const data = await fetcher();
+
+      // cache the result
+      this.cache.set(key, { data, timestamp: Date.now() });
+
+      this._state = { data, loading: false, error: null };
+      this.host.requestUpdate();
+
+      return data;
+    } catch (error) {
+      this._state = { data: null, loading: false, error: error as Error };
+      this.host.requestUpdate();
+      throw error;
+    }
+  }
+
+  clear() {
+    this._state = { data: null, loading: false, error: null };
+    this.cache.clear();
+    this.host.requestUpdate();
+  }
+
+  hostConnected() {}
+
+  hostDisconnected() {
+    this.cache.clear();
+  }
+}


### PR DESCRIPTION
fetching data should be done through Lit controllers (https://lit.dev/docs/composition/controllers/) allowing the component lifecycle to be better managed.

- Add a generic controller with a simple cache and state management. In a future update, we can show error state and loading state for better UX.
- Flesh out the existing api client for missing endpoints (calls to be replaced in a following commit) and simplify the calling chain to return a promise and let it be handled in the component.