### PR TITLE
Remove cjwagner from OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,7 +4,6 @@ aliases:
   sig-testing-leads:
     - BenTheElder
     - aojea
-    - cjwagner
     - jbpratt
     - michelle192837
     - pohly


### PR DESCRIPTION
Syncing this with https://github.com/kubernetes/community/blob/master/sig-testing/README.md#leadership.