### PR TITLE
fix(navigation): support both group and dashboard endpoints

### DIFF
--- a/web/src/testgrid-index.ts
+++ b/web/src/testgrid-index.ts
@@ -6,7 +6,7 @@ import {
   ListDashboardGroupsResponse,
 } from './gen/pb/api/v1/data.js';
 import { apiClient } from './APIClient.js';
-import { navigate } from './utils/navigation.js';
+import { navigateWithContext } from './utils/navigation.js';
 import { APIController } from './controllers/api-controller.js';
 import '@material/mwc-list';
 import '@material/mwc-list/mwc-list-item.js';
@@ -126,11 +126,11 @@ export class TestgridIndex extends LitElement {
         class="grid-card ${item.type}"
         role="button"
         tabindex="0"
-        @click=${() => navigate(item.name)}
+        @click=${() => navigateWithContext(item.name, item.type)}
         @keydown=${(e: KeyboardEvent) => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
-          navigate(item.name);
+          navigateWithContext(item.name, item.type);
         }
       }}
       >
@@ -144,7 +144,7 @@ export class TestgridIndex extends LitElement {
                 ${map(item.children, (child: GridItem, index: number) => html`
                   <mwc-list-item id=${index} @click=${(e: Event) => {
                     e.stopPropagation();
-                    navigate(child.name);
+                    navigateWithContext(child.name, child.type);
                   }}>
                     <p>${child.name}</p>
                   </mwc-list-item>

--- a/web/src/testgrid-router.ts
+++ b/web/src/testgrid-router.ts
@@ -3,6 +3,7 @@ import { customElement } from 'lit/decorators.js';
 import { Router } from '@lit-labs/router';
 import './testgrid-data-content.js';
 import './testgrid-index.js';
+import './testgrid-summary.js';
 
 // Defines the type of params used for rendering components under different paths
 interface RouteParameter {
@@ -34,11 +35,11 @@ export class TestgridRouter extends LitElement {
         ></testgrid-data-content>`,
     },
     {
-      path: '/:dashboard',
+      path: '/:name',
       render: (params: RouteParameter) =>
-        html`<testgrid-data-content
-          .dashboardName=${params.dashboard}
-        ></testgrid-data-content>`,
+        html`<testgrid-summary
+          .name=${params.name}
+        ></testgrid-summary>`,
     },
     {
       path: '/',

--- a/web/src/testgrid-summary.ts
+++ b/web/src/testgrid-summary.ts
@@ -1,0 +1,130 @@
+import { LitElement, html, css, PropertyValues } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import {
+  ListDashboardsResponse,
+  ListDashboardGroupsResponse,
+} from './gen/pb/api/v1/data.js';
+import { apiClient } from './APIClient.js';
+import { APIController } from './controllers/api-controller.js';
+import './testgrid-group-summary.js';
+import './testgrid-data-content.js';
+
+@customElement('testgrid-summary')
+export class TestgridSummary extends LitElement {
+  private dashboardGroupsController = new APIController<ListDashboardGroupsResponse>(this);
+
+  private dashboardsController = new APIController<ListDashboardsResponse>(this);
+
+  @property({ type: String })
+  name = '';
+
+  @state()
+  summaryType: 'dashboard-group' | 'dashboard' | 'unknown' = 'unknown';
+
+  @state()
+  isLoading = true;
+
+  static styles = css`
+    :host {
+      display: block;
+      width: 100%;
+      height: 100%;
+    }
+
+    .loading {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 200px;
+      font-size: 16px;
+      color: #666;
+    }
+
+    .not-found {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      height: 200px;
+      font-size: 18px;
+      color: #d32f2f;
+    }
+
+    .not-found-subtitle {
+      font-size: 14px;
+      color: #666;
+      margin-top: 8px;
+    }
+  `;
+
+  connectedCallback() {
+    // eslint-disable-next-line wc/guard-super-call
+    super.connectedCallback();
+    this.determineSummaryType();
+  }
+
+  willUpdate(changedProperties: PropertyValues) {
+    if (changedProperties.has('name')) {
+      this.isLoading = true;
+      this.determineSummaryType();
+    }
+  }
+
+  private async determineSummaryType() {
+    const historyState = window.history.state;
+    if (historyState && historyState.type) {
+      this.summaryType = historyState.type;
+      this.isLoading = false;
+      return;
+    }
+
+    try {
+      const [groupsResponse, dashboardsResponse] = await Promise.all([
+        this.dashboardGroupsController.fetch('dashboard-groups', () => apiClient.getDashboardGroups()),
+        this.dashboardsController.fetch('dashboards', () => apiClient.getDashboards())
+      ]);
+
+      const isGroup = groupsResponse.dashboardGroups?.some(g => g.name === this.name);
+      if (isGroup) {
+        this.summaryType = 'dashboard-group';
+        this.isLoading = false;
+        return;
+      }
+
+      const isDashboard = dashboardsResponse.dashboards?.some(d => d.name === this.name);
+      if (isDashboard) {
+        this.summaryType = 'dashboard';
+        this.isLoading = false;
+        return;
+      }
+
+      this.isLoading = false;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to determine summary type:', error);
+      this.isLoading = false;
+    }
+  }
+
+  render() {
+    if (this.isLoading) {
+      return html`<div class="loading">Loading...</div>`;
+    }
+
+    switch (this.summaryType) {
+      case 'dashboard-group':
+        return html`<testgrid-group-summary .groupName=${this.name}></testgrid-group-summary>`;
+      case 'dashboard':
+        return html`<testgrid-data-content .dashboardName=${this.name}></testgrid-data-content>`;
+      default:
+        return html`
+          <div class="not-found">
+            <div>Not found: ${this.name}</div>
+            <div class="not-found-subtitle">
+              The requested dashboard or group could not be found.
+            </div>
+          </div>
+        `;
+    }
+  }
+}

--- a/web/src/utils/navigation.ts
+++ b/web/src/utils/navigation.ts
@@ -11,6 +11,19 @@ export function navigate(name: string) {
 }
 
 /**
+ * Navigates application to a specified page with context about the item type.
+ * @fires location-changed
+ * @param {string} name - The name of the dashboard or group
+ * @param {'dashboard-group' | 'dashboard'} type - The type of item being navigated to
+ */
+export function navigateWithContext(name: string, type: 'dashboard-group' | 'dashboard') {
+  const url = new URL(window.location.href);
+  url.pathname = name;
+  window.history.pushState({ type }, '', url);
+  window.dispatchEvent(new CustomEvent('location-changed', { detail: { type } }));
+}
+
+/**
  * Changes the URL without reloading
  * @param {string} dashboard
  * @param {string} tab

--- a/web/test/testgrid-router.test.ts
+++ b/web/test/testgrid-router.test.ts
@@ -34,7 +34,7 @@ describe('Testgrid Router navigation', () => {
     navigate('fake-dashboard-1');
 
     await waitUntil(
-      () => element.shadowRoot!.querySelector('testgrid-data-content'),
+      () => element.shadowRoot!.querySelector('testgrid-summary'),
       'Router did not navigate to dashboard route',
       { timeout: 4000 }
     );


### PR DESCRIPTION
add a top level summary component that determines whether to render the
dashboard group summary or to render the dashboard summary. This seems a
bit inefficient but this is the behavior of the old UI. The index sets
the type based on the griditem then we confirm when loading the summary.
We still need to do this check in case the endpoint is navigated to
directly
