### PR TITLE
fix: typescript eslint

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -73,9 +73,7 @@
     ],
     "rules": {
       "no-unused-vars": "off",
-      "@typescript-eslint/no-unused-vars": [
-        "error"
-      ],
+      "@typescript-eslint/no-unused-vars": "error",
       "import/no-unresolved": "off",
       "import/extensions": [
         "error",


### PR DESCRIPTION
I am getting this `"Incorrect type. Expected 'integer'"`
so i changed it to `"@typescript-eslint/no-unused-vars": "error",`

ref: https://typescript-eslint.io/rules/no-unused-vars/#how-to-use