### PR TITLE
feat(web): add header with breadcrumbs and search

### DIFF
--- a/web/src/contexts/navigation-context.ts
+++ b/web/src/contexts/navigation-context.ts
@@ -1,0 +1,32 @@
+import { createContext } from '@lit/context';
+
+/**
+ * Represents a breadcrumb item in the navigation hierarchy
+ */
+export interface BreadcrumbItem {
+  label: string;
+  path: string;
+  type: 'index' | 'group' | 'dashboard' | 'tab';
+  dashboardGroupName?: string;  // Parent group for dashboards/tabs
+}
+
+/**
+ * Navigation state shared across components
+ */
+export interface NavigationState {
+  breadcrumbs: BreadcrumbItem[];
+  searchQuery: string;
+}
+
+/**
+ * Default navigation state
+ */
+export const defaultNavigationState: NavigationState = {
+  breadcrumbs: [{ label: 'Index', path: '/', type: 'index' }],
+  searchQuery: '',
+};
+
+/**
+ * Context for sharing navigation state across the app
+ */
+export const navigationContext = createContext<NavigationState>('testgrid-navigation-context');

--- a/web/src/styles/shared-styles.ts
+++ b/web/src/styles/shared-styles.ts
@@ -19,6 +19,14 @@ export const sharedStyles = css`
     --tg-surface: #fff;
     --tg-text: #333;
 
+    /* Header colors */
+    --tg-header-bg: #1a1a2e;
+    --tg-header-text: #fff;
+    --tg-header-height: 56px;
+    --tg-breadcrumb-separator: #888;
+    --tg-link-color: #707df1;
+    --tg-link-hover-color: #5a67d8;
+
     /* Test status colors */
     --tg-status-pass: #4caf50;
     --tg-status-fail: #f44336;

--- a/web/src/testgrid-app.ts
+++ b/web/src/testgrid-app.ts
@@ -1,5 +1,9 @@
 import { LitElement, html, css } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, state } from 'lit/decorators.js';
+import { provide } from '@lit/context';
+import { navigationContext, NavigationState, BreadcrumbItem, defaultNavigationState } from './contexts/navigation-context.js';
+import { sharedStyles } from './styles/shared-styles.js';
+import './testgrid-header.js';
 import './testgrid-router.js';
 
 // @ts-ignore: Property 'UrlPattern' does not exist
@@ -14,19 +18,100 @@ if (!globalThis.URLPattern) {
  */
 @customElement('testgrid-app')
 export class TestgridApp extends LitElement {
-  static styles = css`
+  @provide({ context: navigationContext })
+  @state()
+  navigationState: NavigationState = defaultNavigationState;
+
+  private handleLocationChanged = () => {
+    this.updateBreadcrumbs();
+  };
+
+  connectedCallback() {
+    // eslint-disable-next-line wc/guard-super-call
+    super.connectedCallback();
+    window.addEventListener('location-changed', this.handleLocationChanged);
+    window.addEventListener('popstate', this.handleLocationChanged);
+    this.updateBreadcrumbs();
+  }
+
+  disconnectedCallback() {
+    // eslint-disable-next-line wc/guard-super-call
+    super.disconnectedCallback();
+    window.removeEventListener('location-changed', this.handleLocationChanged);
+    window.removeEventListener('popstate', this.handleLocationChanged);
+  }
+
+  private updateBreadcrumbs() {
+    const {pathname} = window.location;
+    const segments = pathname.split('/').filter(Boolean).map(s => decodeURIComponent(s));
+    const historyState = window.history.state;
+
+    const breadcrumbs: BreadcrumbItem[] = [
+      { label: 'Index', path: '/', type: 'index' }
+    ];
+
+    if (segments.length > 0) {
+      const firstName = segments[0];
+      const isGroup = historyState?.type === 'dashboard-group';
+      const dashboardGroupName = historyState?.dashboardGroupName;
+
+      // If this dashboard belongs to a group, show group first
+      if (dashboardGroupName && !isGroup) {
+        breadcrumbs.push({
+          label: dashboardGroupName,
+          path: `/${encodeURIComponent(dashboardGroupName)}`,
+          type: 'group'
+        });
+      }
+
+      // Add the current page (group or dashboard)
+      breadcrumbs.push({
+        label: firstName,
+        path: `/${encodeURIComponent(firstName)}`,
+        type: isGroup ? 'group' : 'dashboard',
+        dashboardGroupName
+      });
+
+      // Tab name if present
+      if (segments.length > 1) {
+        const tabName = segments.slice(1).join('/');
+        breadcrumbs.push({
+          label: tabName,
+          path: `/${encodeURIComponent(firstName)}/${encodeURIComponent(tabName)}`,
+          type: 'tab',
+          dashboardGroupName
+        });
+      }
+    }
+
+    this.navigationState = {
+      ...this.navigationState,
+      breadcrumbs
+    };
+  }
+
+  static styles = [sharedStyles, css`
     :host {
-      display: block;
+      display: flex;
+      flex-direction: column;
       width: 100vw;
       height: 100vh;
+      overflow: hidden;
     }
-  `;
 
-  /**
-   * Lit-element lifecycle method.
-   * Invoked on each update to perform rendering tasks.
-   */
+    .main-content {
+      flex: 1;
+      overflow: auto;
+      background: var(--tg-surface);
+    }
+  `];
+
   render() {
-    return html`<testgrid-router></testgrid-router>`;
+    return html`
+      <testgrid-header></testgrid-header>
+      <main class="main-content">
+        <testgrid-router></testgrid-router>
+      </main>
+    `;
   }
 }

--- a/web/src/testgrid-data-content.ts
+++ b/web/src/testgrid-data-content.ts
@@ -1,16 +1,11 @@
 import { LitElement, html, css } from 'lit';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { customElement, property, state } from 'lit/decorators.js';
-import { map } from 'lit/directives/map.js';
-import { when } from 'lit/directives/when.js';
 import { provide } from '@lit/context';
 import { navigateTab } from './utils/navigation.js';
 import { ListDashboardTabsResponse } from './gen/pb/api/v1/data.js';
 import { type TestGridLinkTemplate, linkContext } from './testgrid-context.js';
 import { APIController } from './controllers/api-controller.js';
 import { apiClient } from './APIClient.js';
-import '@material/web/tabs/tabs.js';
-import '@material/web/tabs/primary-tab.js';
 import './testgrid-dashboard-summary.js';
 import './testgrid-grid.js';
 
@@ -23,16 +18,9 @@ import './testgrid-grid.js';
 export class TestgridDataContent extends LitElement {
   static styles = css`
     :host {
-      display: grid;
-      grid-template-rows: minmax(1em, auto) minmax(0, 100%);
+      display: block;
       width: 100%;
       height: 100%;
-    }
-
-    md-primary-tab {
-      --md-sys-typescale-label-large-size: 0.8rem;
-      --md-sys-typescale-label-large-tracking: 0;
-      padding-inline: 12px;
     }
   `;
 
@@ -55,23 +43,6 @@ export class TestgridDataContent extends LitElement {
   linkTemplate: TestGridLinkTemplate = { url: new URL('https://prow.k8s.io/') };
 
   private tabsController = new APIController<ListDashboardTabsResponse>(this);
-
-  // set the functionality when any tab is clicked on
-  private onTabActivated(event: CustomEvent<{ index: number }>) {
-    const tabIndex = (event.target as any).activeTabIndex ?? (event as any).detail?.index;
-
-    if (tabIndex === this.activeIndex) {
-      return;
-    }
-
-    this.tabName = this.tabNames[tabIndex];
-
-    if (this.activeIndex === 0 || tabIndex === 0) {
-      this.showTab = !this.showTab;
-    }
-    this.activeIndex = tabIndex;
-    navigateTab(this.dashboardName, this.tabName);
-  }
 
   private handleTabChanged = (evt: Event) => {
     this.tabName = (<CustomEvent>evt).detail.tabName;
@@ -106,24 +77,7 @@ export class TestgridDataContent extends LitElement {
    * Invoked on each update to perform rendering tasks.
    */
   render() {
-    const tabBar = html`${
-      // make sure we only render the tabs when there are tabs
-      when(
-        this.tabNames.length > 0,
-        () => html` <md-tabs
-          style="width: 100vw"
-          .activeIndex=${this.activeIndex}
-          @change="${this.onTabActivated}"
-        >
-          ${map(
-            this.tabNames,
-            (name: string) => html`<md-primary-tab>${name}</md-primary-tab>`
-          )}
-        </md-tabs>`
-      )
-    }`;
     return html`
-      ${tabBar}
       ${!this.showTab
         ? html`<testgrid-dashboard-summary
             .dashboardName=${this.dashboardName}

--- a/web/src/testgrid-group-summary.ts
+++ b/web/src/testgrid-group-summary.ts
@@ -8,7 +8,7 @@ import {
 import { APIController } from './controllers/api-controller.js';
 import { apiClient } from './APIClient.js';
 import { sharedStyles } from './styles/shared-styles.js';
-import { navigate } from './utils/navigation.js';
+import { navigateWithContext } from './utils/navigation.js';
 import './testgrid-status-indicator.js';
 
 /**
@@ -60,7 +60,7 @@ export class TestgridGroupSummary extends LitElement {
                     <testgrid-status-indicator status="${ds.overallStatus}"></testgrid-status-indicator>
                   </td>
                   <td>
-                    <a href="#" @click=${(e: Event) => TestgridGroupSummary.handleDashboardClick(e, ds.name)} class="dashboard-link">
+                    <a href="#" @click=${(e: Event) => this.handleDashboardClick(e, ds.name)} class="dashboard-link">
                       ${ds.name}
                     </a>
                   </td>
@@ -114,9 +114,9 @@ export class TestgridGroupSummary extends LitElement {
     this.overallSummary = { totalPassing, totalTabs };
   }
 
-  private static handleDashboardClick(event: Event, dashboardName: string) {
+  private handleDashboardClick(event: Event, dashboardName: string) {
     event.preventDefault();
-    navigate(dashboardName);
+    navigateWithContext(dashboardName, 'dashboard', this.groupName);
   }
 
   private static convertResponse(summary: DashboardSummary) {

--- a/web/src/testgrid-header.ts
+++ b/web/src/testgrid-header.ts
@@ -1,0 +1,415 @@
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { consume } from '@lit/context';
+import { map } from 'lit/directives/map.js';
+import { sharedStyles } from './styles/shared-styles.js';
+import { navigationContext, NavigationState, BreadcrumbItem, defaultNavigationState } from './contexts/navigation-context.js';
+import { apiClient } from './APIClient.js';
+import { navigateWithContext } from './utils/navigation.js';
+import { ListDashboardsResponse } from './gen/pb/api/v1/data.js';
+
+interface SearchResult {
+  name: string;
+  type: 'dashboard' | 'group';
+  dashboardGroupName?: string;
+}
+
+/**
+ * Global header component with logo, breadcrumbs, and search.
+ */
+@customElement('testgrid-header')
+export class TestgridHeader extends LitElement {
+  @consume({ context: navigationContext, subscribe: true })
+  @property({ attribute: false })
+  navigationState: NavigationState = defaultNavigationState;
+
+  @state()
+  private searchValue = '';
+
+  @state()
+  private searchResults: SearchResult[] = [];
+
+  @state()
+  private showResults = false;
+
+  @state()
+  private dashboards: ListDashboardsResponse | null = null;
+
+  connectedCallback() {
+    // eslint-disable-next-line wc/guard-super-call
+    super.connectedCallback();
+    this.loadDashboards();
+    document.addEventListener('click', this.handleOutsideClick);
+  }
+
+  disconnectedCallback() {
+    // eslint-disable-next-line wc/guard-super-call
+    super.disconnectedCallback();
+    document.removeEventListener('click', this.handleOutsideClick);
+  }
+
+  private handleOutsideClick = (e: Event) => {
+    const target = e.target as Node | null;
+    if (target && !this.contains(target)) {
+      this.showResults = false;
+    }
+  };
+
+  private async loadDashboards() {
+    try {
+      this.dashboards = await apiClient.getDashboards();
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to load dashboards for search:', error);
+    }
+  }
+
+  render() {
+    return html`
+      <header class="header">
+        <div class="header-content">
+          <div class="header-left">
+            <a href="/" class="logo" @click=${this.handleLogoClick}>
+              <span class="logo-text">TestGrid</span>
+            </a>
+            <nav class="breadcrumbs" aria-label="Breadcrumb">
+              ${map(this.navigationState.breadcrumbs, (item, index) =>
+                this.renderBreadcrumb(item, index, this.navigationState.breadcrumbs.length)
+              )}
+            </nav>
+          </div>
+          <div class="header-right">
+            <div class="search-container">
+              <div class="search-wrapper">
+                <span class="search-icon">search</span>
+                <input
+                  type="text"
+                  class="search-input"
+                  placeholder="Search dashboards and tabs..."
+                  .value=${this.searchValue}
+                  @input=${this.handleSearchInput}
+                  @focus=${this.handleSearchFocus}
+                  @keydown=${this.handleSearchKeydown}
+                />
+              </div>
+              ${this.showResults && this.searchValue.length > 0 ? this.renderSearchResults() : nothing}
+            </div>
+          </div>
+        </div>
+      </header>
+    `;
+  }
+
+  private renderSearchResults() {
+    if (this.searchResults.length === 0) {
+      return html`
+        <div class="search-results">
+          <div class="search-result-empty">No results found</div>
+        </div>
+      `;
+    }
+
+    return html`
+      <div class="search-results">
+        ${map(this.searchResults, (result) => html`
+          <button
+            class="search-result-item"
+            @click=${() => this.handleResultClick(result)}
+          >
+            <span class="result-name">${result.name}</span>
+            ${result.dashboardGroupName ? html`<span class="result-parent">in ${result.dashboardGroupName}</span>` : nothing}
+          </button>
+        `)}
+      </div>
+    `;
+  }
+
+  private renderBreadcrumb(item: BreadcrumbItem, index: number, total: number) {
+    // Skip "index" type - TestGrid logo serves as home link
+    if (item.type === 'index') {
+      return '';
+    }
+
+    const isLast = index === total - 1;
+    const isFirst = index === 1; // First after home
+
+    return html`
+      ${!isFirst ? html`<span class="separator">/</span>` : ''}
+      ${isLast
+        ? html`<span class="breadcrumb-current">${item.label}</span>`
+        : html`<a
+            href="${item.path}"
+            class="breadcrumb-link"
+            @click=${(e: Event) => this.handleBreadcrumbClick(e, item)}
+          >${item.label}</a>`
+      }
+    `;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  private handleLogoClick(e: Event) {
+    e.preventDefault();
+    window.history.pushState(null, '', '/');
+    window.dispatchEvent(new CustomEvent('location-changed'));
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  private handleBreadcrumbClick(e: Event, item: BreadcrumbItem) {
+    e.preventDefault();
+    const historyState = {
+      type: item.type === 'group' ? 'dashboard-group' : 'dashboard',
+      dashboardGroupName: item.dashboardGroupName
+    };
+    window.history.pushState(historyState, '', item.path);
+    window.dispatchEvent(new CustomEvent('location-changed'));
+  }
+
+  private handleSearchInput(e: Event) {
+    const input = e.target as HTMLInputElement;
+    this.searchValue = input.value;
+    this.performSearch(this.searchValue);
+  }
+
+  private handleSearchFocus() {
+    if (this.searchValue.length > 0) {
+      this.showResults = true;
+    }
+  }
+
+  private handleSearchKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') {
+      this.showResults = false;
+    } else if (e.key === 'Enter' && this.searchResults.length > 0) {
+      this.handleResultClick(this.searchResults[0]);
+    }
+  }
+
+  private performSearch(query: string) {
+    if (!this.dashboards || query.length === 0) {
+      this.searchResults = [];
+      this.showResults = false;
+      return;
+    }
+
+    const lowerQuery = query.toLowerCase();
+    const results: SearchResult[] = [];
+
+    // Search dashboards
+    for (const dashboard of this.dashboards.dashboards) {
+      if (dashboard.name.toLowerCase().includes(lowerQuery)) {
+        results.push({
+          name: dashboard.name,
+          type: 'dashboard',
+          dashboardGroupName: dashboard.dashboardGroupName || undefined
+        });
+      }
+    }
+
+    // Sort by name
+    results.sort((a, b) => a.name.localeCompare(b.name));
+
+    this.searchResults = results;
+    this.showResults = true;
+  }
+
+  private handleResultClick(result: SearchResult) {
+    this.showResults = false;
+    this.searchValue = '';
+    navigateWithContext(result.name, 'dashboard', result.dashboardGroupName);
+  }
+
+  static styles = [sharedStyles, css`
+    :host {
+      display: block;
+      font-family: var(--font-family);
+    }
+
+    .header {
+      background: var(--tg-header-bg);
+      color: var(--tg-header-text);
+      height: var(--tg-header-height);
+      display: flex;
+      align-items: center;
+      padding: 0 1rem;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+
+    .header-content {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      width: 100%;
+      max-width: 1600px;
+      margin: 0 auto;
+    }
+
+    .header-left {
+      display: flex;
+      align-items: center;
+      gap: 1.5rem;
+      flex: 1;
+      min-width: 0;
+    }
+
+    .header-right {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+    }
+
+    .logo {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      text-decoration: none;
+      color: inherit;
+      font-weight: 600;
+      font-size: 1.25rem;
+      flex-shrink: 0;
+    }
+
+    .logo:hover {
+      opacity: 0.9;
+    }
+
+    .search-icon {
+      font-family: 'Material Icons';
+      font-size: 1.25rem;
+    }
+
+    .breadcrumbs {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.875rem;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .separator {
+      color: var(--tg-breadcrumb-separator);
+    }
+
+    .breadcrumb-link {
+      color: var(--tg-header-text);
+      text-decoration: none;
+      opacity: 0.8;
+      transition: opacity 0.2s;
+    }
+
+    .breadcrumb-link:hover {
+      opacity: 1;
+      text-decoration: underline;
+    }
+
+    .breadcrumb-current {
+      color: var(--tg-header-text);
+      font-weight: 500;
+    }
+
+    .search-container {
+      position: relative;
+    }
+
+    .search-wrapper {
+      display: flex;
+      align-items: center;
+      background: rgba(255, 255, 255, 0.1);
+      border-radius: 4px;
+      padding: 0.25rem 0.75rem;
+      transition: background 0.2s;
+    }
+
+    .search-wrapper:focus-within {
+      background: rgba(255, 255, 255, 0.2);
+    }
+
+    .search-icon {
+      color: rgba(255, 255, 255, 0.7);
+      margin-right: 0.5rem;
+    }
+
+    .search-input {
+      background: transparent;
+      border: none;
+      color: var(--tg-header-text);
+      font-size: 0.875rem;
+      width: 250px;
+      outline: none;
+    }
+
+    .search-input::placeholder {
+      color: rgba(255, 255, 255, 0.5);
+    }
+
+    .search-results {
+      position: absolute;
+      top: 100%;
+      right: 0;
+      margin-top: 4px;
+      background: white;
+      border-radius: 4px;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+      min-width: 350px;
+      max-height: 400px;
+      overflow-y: auto;
+      z-index: 1000;
+    }
+
+    .search-result-item {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      width: 100%;
+      padding: 0.75rem 1rem;
+      border: none;
+      background: transparent;
+      cursor: pointer;
+      text-align: left;
+      border-bottom: 1px solid var(--tg-border-light);
+      transition: background 0.1s;
+    }
+
+    .search-result-item:hover {
+      background: var(--tg-border-light);
+    }
+
+    .search-result-item:last-child {
+      border-bottom: none;
+    }
+
+    .result-name {
+      font-size: 0.875rem;
+      color: var(--tg-text);
+      font-weight: 500;
+    }
+
+    .result-parent {
+      font-size: 0.75rem;
+      color: #666;
+      margin-top: 2px;
+    }
+
+    .search-result-empty {
+      padding: 1rem;
+      color: #666;
+      text-align: center;
+      font-size: 0.875rem;
+    }
+
+    @media (max-width: 768px) {
+      .breadcrumbs {
+        display: none;
+      }
+
+      .search-input {
+        width: 150px;
+      }
+
+      .search-results {
+        min-width: 280px;
+      }
+    }
+  `];
+}

--- a/web/src/utils/navigation.ts
+++ b/web/src/utils/navigation.ts
@@ -15,16 +15,17 @@ export function navigate(name: string) {
  * @fires location-changed
  * @param {string} name - The name of the dashboard or group
  * @param {'dashboard-group' | 'dashboard'} type - The type of item being navigated to
+ * @param {string} dashboardGroupName - Optional parent group name for dashboards
  */
-export function navigateWithContext(name: string, type: 'dashboard-group' | 'dashboard') {
+export function navigateWithContext(name: string, type: 'dashboard-group' | 'dashboard', dashboardGroupName?: string) {
   const url = new URL(window.location.href);
   url.pathname = name;
-  window.history.pushState({ type }, '', url);
-  window.dispatchEvent(new CustomEvent('location-changed', { detail: { type } }));
+  window.history.pushState({ type, dashboardGroupName }, '', url);
+  window.dispatchEvent(new CustomEvent('location-changed', { detail: { type, dashboardGroupName } }));
 }
 
 /**
- * Changes the URL without reloading
+ * Changes the URL without reloading, preserving navigation context
  * @param {string} dashboard
  * @param {string} tab
  */
@@ -35,6 +36,8 @@ export function navigateTab(dashboard: string, tab?: string) {
   } else {
     url.pathname = `${dashboard}/${tab}`;
   }
-  window.history.pushState(null, '', url);
+  // Preserve existing history state (type, dashboardGroupName) when switching tabs
+  const existingState = window.history.state || {};
+  window.history.pushState(existingState, '', url);
   window.dispatchEvent(new CustomEvent('location-changed'));
 }

--- a/web/test/testgrid-data-content.test.ts
+++ b/web/test/testgrid-data-content.test.ts
@@ -7,7 +7,6 @@ import {
   waitUntil,
 } from '@open-wc/testing';
 
-import { MdPrimaryTab as Tab } from '@material/web/tabs/primary-tab.js';
 import { TestgridDataContent } from '../src/testgrid-data-content.js';
 
 describe('Testgrid Data Content page', () => {
@@ -22,12 +21,10 @@ describe('Testgrid Data Content page', () => {
     );
   });
 
-  // TODO - add accessibility tests
-  // TODO - add tests for tab switching behaviour
-  it('fetches the tab names and renders the tab bar', async () => {
+  it('fetches the tab names', async () => {
     await waitUntil(
-      () => element.shadowRoot!.querySelector('md-tabs'),
-      'Data content did not render the tab bar',
+      () => element.tabNames.length > 0,
+      'Data content did not fetch tab names',
       {
         timeout: 4000,
       }
@@ -36,73 +33,7 @@ describe('Testgrid Data Content page', () => {
     expect(element.tabNames).to.not.be.empty;
   });
 
-  it('renders the dashboard summary if `showTab` attribute is not passed', async () => {
-    await waitUntil(
-      () => element.shadowRoot!.querySelector('md-tabs'),
-      'Data content did not render the tab bar',
-      {
-        timeout: 4000,
-      }
-    );
-
-    expect(element.tabNames).to.not.be.empty;
-    expect(element.activeIndex).to.equal(0);
-    expect(window.location.pathname).to.equal('/');
-  });
-
-  it('renders the grid display if a tab is clicked', async () => {
-    await waitUntil(
-      () => element.shadowRoot!.querySelector('md-primary-tab'),
-      'Data content did not render the tab bar',
-      {
-        timeout: 4000,
-      }
-    );
-
-    const tab: NodeListOf<Tab> | null =
-      element.shadowRoot!.querySelectorAll('md-primary-tab');
-    tab[1]!.click();
-
-    await waitUntil(
-      () => element.shadowRoot!.querySelector('testgrid-grid'),
-      'Data content did not render the grid data',
-      {
-        timeout: 4000,
-      }
-    );
-
-    expect(element.activeIndex).to.equal(1);
-    expect(element.showTab).to.equal(true);
-    expect(window.location.pathname).to.equal('/fake-dashboard-1/fake-tab-1');
-  });
-
-  it('renders the grid display, then dashboard summary when clicked', async () => {
-    await waitUntil(
-      () => element.shadowRoot!.querySelector('md-tabs'),
-      'Data content did not render the tab bar',
-      {
-        timeout: 4000,
-      }
-    );
-
-    const tab: NodeListOf<Tab> | null =
-      element.shadowRoot!.querySelectorAll('md-primary-tab');
-    tab[1]!.click();
-
-    await waitUntil(
-      () => element.shadowRoot!.querySelector('testgrid-grid'),
-      'Data content did not render the grid data',
-      {
-        timeout: 4000,
-      }
-    );
-
-    expect(element.activeIndex).to.equal(1);
-    expect(element.showTab).to.equal(true);
-    expect(window.location.pathname).to.equal('/fake-dashboard-1/fake-tab-1');
-
-    tab[0]!.click();
-
+  it('renders the dashboard summary if `showTab` is false', async () => {
     await waitUntil(
       () => element.shadowRoot!.querySelector('testgrid-dashboard-summary'),
       'Data content did not render the dashboard summary',
@@ -111,8 +42,64 @@ describe('Testgrid Data Content page', () => {
       }
     );
 
-    expect(element.activeIndex).to.equal(0);
     expect(element.showTab).to.equal(false);
-    expect(window.location.pathname).to.equal('/fake-dashboard-1');
+    const dashboardSummary = element.shadowRoot!.querySelector('testgrid-dashboard-summary');
+    expect(dashboardSummary).to.exist;
+  });
+
+  it('renders the grid display if `showTab` is true', async () => {
+    element.showTab = true;
+    element.tabName = 'fake-tab-1';
+    await element.updateComplete;
+
+    await waitUntil(
+      () => element.shadowRoot!.querySelector('testgrid-grid'),
+      'Data content did not render the grid',
+      {
+        timeout: 4000,
+      }
+    );
+
+    const grid = element.shadowRoot!.querySelector('testgrid-grid');
+    expect(grid).to.exist;
+  });
+
+  it('switches between summary and grid based on showTab', async () => {
+    // Initially shows dashboard summary
+    await waitUntil(
+      () => element.shadowRoot!.querySelector('testgrid-dashboard-summary'),
+      'Data content did not render the dashboard summary',
+      {
+        timeout: 4000,
+      }
+    );
+    expect(element.showTab).to.equal(false);
+
+    // Switch to grid
+    element.showTab = true;
+    element.tabName = 'fake-tab-1';
+    await element.updateComplete;
+
+    await waitUntil(
+      () => element.shadowRoot!.querySelector('testgrid-grid'),
+      'Data content did not render the grid',
+      {
+        timeout: 4000,
+      }
+    );
+    expect(element.shadowRoot!.querySelector('testgrid-dashboard-summary')).to.not.exist;
+
+    // Switch back to summary
+    element.showTab = false;
+    await element.updateComplete;
+
+    await waitUntil(
+      () => element.shadowRoot!.querySelector('testgrid-dashboard-summary'),
+      'Data content did not render the dashboard summary after switching back',
+      {
+        timeout: 4000,
+      }
+    );
+    expect(element.shadowRoot!.querySelector('testgrid-grid')).to.not.exist;
   });
 });

--- a/web/test/testgrid-header.test.ts
+++ b/web/test/testgrid-header.test.ts
@@ -1,0 +1,122 @@
+import {
+  html,
+  fixture,
+  defineCE,
+  unsafeStatic,
+  expect,
+  waitUntil,
+} from '@open-wc/testing';
+
+import { TestgridHeader } from '../src/testgrid-header.js';
+
+describe('Testgrid Header', () => {
+  let element: TestgridHeader;
+  beforeEach(async () => {
+    const tagName = defineCE(class extends TestgridHeader {});
+    const tag = unsafeStatic(tagName);
+    element = await fixture(html`<${tag}></${tag}>`);
+  });
+
+  it('renders the header with logo and search input', async () => {
+    const logo = element.shadowRoot!.querySelector('.logo');
+    expect(logo).to.exist;
+    expect(logo!.textContent).to.include('TestGrid');
+
+    const searchInput = element.shadowRoot!.querySelector('.search-input');
+    expect(searchInput).to.exist;
+  });
+
+  it('shows search results when typing a query', async () => {
+    // Wait for dashboards to load
+    await waitUntil(
+      () => (element as any).dashboards !== null,
+      'Dashboards did not load',
+      { timeout: 4000 }
+    );
+
+    const searchInput = element.shadowRoot!.querySelector(
+      '.search-input'
+    ) as HTMLInputElement;
+    expect(searchInput).to.exist;
+
+    // Type a search query
+    searchInput.value = 'fake';
+    searchInput.dispatchEvent(new Event('input'));
+    await element.updateComplete;
+
+    // Wait for search results to appear
+    await waitUntil(
+      () => element.shadowRoot!.querySelector('.search-results'),
+      'Search results did not appear',
+      { timeout: 4000 }
+    );
+
+    const results = element.shadowRoot!.querySelectorAll('.search-result-item');
+    expect(results.length).to.be.greaterThan(0);
+  });
+
+  it('shows no results message for non-matching query', async () => {
+    // Wait for dashboards to load
+    await waitUntil(
+      () => (element as any).dashboards !== null,
+      'Dashboards did not load',
+      { timeout: 4000 }
+    );
+
+    const searchInput = element.shadowRoot!.querySelector(
+      '.search-input'
+    ) as HTMLInputElement;
+    expect(searchInput).to.exist;
+
+    // Type a non-matching query
+    searchInput.value = 'zzzznonexistent';
+    searchInput.dispatchEvent(new Event('input'));
+    await element.updateComplete;
+
+    // Wait for search results container to appear
+    await waitUntil(
+      () => element.shadowRoot!.querySelector('.search-results'),
+      'Search results container did not appear',
+      { timeout: 4000 }
+    );
+
+    const emptyMessage = element.shadowRoot!.querySelector(
+      '.search-result-empty'
+    );
+    expect(emptyMessage).to.exist;
+    expect(emptyMessage!.textContent).to.include('No results found');
+  });
+
+  it('hides search results when Escape is pressed', async () => {
+    // Wait for dashboards to load
+    await waitUntil(
+      () => (element as any).dashboards !== null,
+      'Dashboards did not load',
+      { timeout: 4000 }
+    );
+
+    const searchInput = element.shadowRoot!.querySelector(
+      '.search-input'
+    ) as HTMLInputElement;
+
+    // Type a search query
+    searchInput.value = 'fake';
+    searchInput.dispatchEvent(new Event('input'));
+    await element.updateComplete;
+
+    // Wait for search results to appear
+    await waitUntil(
+      () => element.shadowRoot!.querySelector('.search-results'),
+      'Search results did not appear',
+      { timeout: 4000 }
+    );
+
+    // Press Escape
+    searchInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    await element.updateComplete;
+
+    // Results should be hidden
+    const results = element.shadowRoot!.querySelector('.search-results');
+    expect(results).to.not.exist;
+  });
+});

--- a/web/test/testgrid-index.test.ts
+++ b/web/test/testgrid-index.test.ts
@@ -16,7 +16,7 @@ describe('Testgrid Index page', () => {
     element = await fixture(html`<${tag}></${tag}>`);
   });
 
-  it('renders data and handles search', async () => {
+  it('renders dashboard groups and standalone dashboards', async () => {
     element.dashboardGroups = {
       'group-alpha': ['dashboard-1', 'dashboard-2'],
       'group-beta': ['dashboard-3']
@@ -24,25 +24,8 @@ describe('Testgrid Index page', () => {
     element.ungroupedDashboards = ['standalone-dashboard'];
     await element.updateComplete;
 
-    let cards = element.shadowRoot!.querySelectorAll('.grid-card');
+    const cards = element.shadowRoot!.querySelectorAll('.grid-card');
     expect(cards).to.have.length(3); // 2 groups + 1 standalone
-
-    const searchInput = element.shadowRoot!.querySelector('.search-input') as HTMLInputElement;
-    searchInput.value = 'alpha';
-    searchInput.dispatchEvent(new Event('input'));
-    await element.updateComplete;
-
-    cards = element.shadowRoot!.querySelectorAll('.grid-card');
-    expect(cards).to.have.length(1);
-    expect(cards[0].querySelector('.card-title')?.textContent).to.equal('group-alpha');
-
-    searchInput.value = 'STANDALONE';
-    searchInput.dispatchEvent(new Event('input'));
-    await element.updateComplete;
-
-    cards = element.shadowRoot!.querySelectorAll('.grid-card');
-    expect(cards).to.have.length(1);
-    expect(cards[0].querySelector('.card-title')?.textContent).to.equal('standalone-dashboard');
   });
 
   it('shows dashboard tooltips for groups', async () => {


### PR DESCRIPTION
I've found navigation to be confusing so attempting to centralize it within a
header and move searching there

Signed-off-by: Brady Pratt <bpratt@redhat.com>

Screenshots below!

<details>

<img width="780" height="493" alt="nav-test-home" src="https://github.com/user-attachments/assets/951ade32-7953-4f5b-9c0f-cd489286ab5f" />

<img width="780" height="493" alt="nav-test-breadcrumb" src="https://github.com/user-attachments/assets/14528e2a-46cc-4eab-a4c1-5117e6948c5b" />

<img width="780" height="493" alt="nav-test-search" src="https://github.com/user-attachments/assets/3e14c87c-e81b-4f06-b43d-0f348c643c51" />

<img width="780" height="493" alt="nav-test-nested-breadcrumb" src="https://github.com/user-attachments/assets/dd17c2db-43b3-479e-940c-46184ef064f6" />

</details>
